### PR TITLE
Better inline code escaping

### DIFF
--- a/tests/extensions/inlinehilite.html
+++ b/tests/extensions/inlinehilite.html
@@ -2,3 +2,8 @@
 <p>Another test <code class="inlinehilite"><span class="kn">import</span> <span class="nn">module</span></code>.</p>
 <p>Escape mock shebang with a space <code class="inlinehilite">#!python import module</code>.</p>
 <p>Check bad language <code class="inlinehilite">import module</code>.</p>
+<p><code class="inlinehilite">Code</code></p>
+<p>`Not code`</p>
+<p>\<code class="inlinehilite">Code</code></p>
+<p>\`Not code`</p>
+<p>\\<code class="inlinehilite">Code</code></p>

--- a/tests/extensions/inlinehilite.txt
+++ b/tests/extensions/inlinehilite.txt
@@ -5,3 +5,13 @@ Another test `:::python import module`.
 Escape mock shebang with a space ` #!python import module`.
 
 Check bad language `#!bad import module`.
+
+`Code`
+
+\`Not code`
+
+\\`Code`
+
+\\\`Not code`
+
+\\\\`Code`


### PR DESCRIPTION
This aims to escape code in a more expected fashion.  This handles when
backticks are escaped and when the escapes before backticks are escaped.

fixes #45